### PR TITLE
ㅛ와 ㅠ가 잘 안써짐

### DIFF
--- a/MoakiKeyboard/Engine/GestureAnalyzer.swift
+++ b/MoakiKeyboard/Engine/GestureAnalyzer.swift
@@ -7,11 +7,14 @@ class GestureAnalyzer {
     private var lastDirectionChangePoint: CGPoint?
 
     private let threshold: CGFloat
+    private let reversalThreshold: CGFloat
     private let directionChangeThreshold: CGFloat
 
     init(threshold: CGFloat = KeyboardMetrics.gestureThreshold,
+         reversalThreshold: CGFloat = KeyboardMetrics.reversalThreshold,
          directionChangeThreshold: CGFloat = KeyboardMetrics.directionChangeThreshold) {
         self.threshold = threshold
+        self.reversalThreshold = reversalThreshold
         self.directionChangeThreshold = directionChangeThreshold
     }
 
@@ -45,17 +48,27 @@ class GestureAnalyzer {
             dy: currentPoint.y - referencePoint.y
         )
 
-        guard let newDirection = GestureDirection.from(vector: vector, threshold: threshold) else {
-            return
+        let magnitude = sqrt(vector.dx * vector.dx + vector.dy * vector.dy)
+
+        // Try detecting direction with standard threshold first
+        var newDirection = GestureDirection.from(vector: vector, threshold: threshold)
+
+        // If standard threshold fails, try lower reversal threshold for opposite directions
+        if newDirection == nil, let lastDirection = directions.last, magnitude >= reversalThreshold {
+            if let candidate = GestureDirection.from(vector: vector, threshold: reversalThreshold),
+               candidate.isOpposite(to: lastDirection) {
+                newDirection = candidate
+            }
         }
+
+        guard let newDirection else { return }
 
         // Check if this is a new direction or continuation
         if let lastDirection = directions.last {
             // Only add if direction changed
             if newDirection != lastDirection {
                 // Make sure we've moved enough from the last direction change
-                let distance = sqrt(vector.dx * vector.dx + vector.dy * vector.dy)
-                if distance >= directionChangeThreshold {
+                if magnitude >= directionChangeThreshold || (newDirection.isOpposite(to: lastDirection) && magnitude >= reversalThreshold) {
                     directions.append(newDirection)
                     lastDirectionChangePoint = currentPoint
                 }

--- a/MoakiKeyboard/Models/GestureDirection.swift
+++ b/MoakiKeyboard/Models/GestureDirection.swift
@@ -68,6 +68,19 @@ enum GestureDirection: String, CaseIterable {
         !isCardinal
     }
 
+    /// Check if two directions are exactly opposite (e.g., up↔down, left↔right)
+    func isOpposite(to other: GestureDirection) -> Bool {
+        switch (self, other) {
+        case (.up, .down), (.down, .up),
+             (.left, .right), (.right, .left),
+             (.upLeft, .downRight), (.downRight, .upLeft),
+             (.upRight, .downLeft), (.downLeft, .upRight):
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Check if two directions are adjacent (e.g., up and upRight are adjacent)
     func isAdjacentTo(_ other: GestureDirection) -> Bool {
         let adjacencyMap: [GestureDirection: Set<GestureDirection>] = [

--- a/MoakiKeyboard/Models/VowelPattern.swift
+++ b/MoakiKeyboard/Models/VowelPattern.swift
@@ -21,8 +21,12 @@ struct VowelPattern {
         // Y-vowels (triple direction)
         VowelPattern(.ㅛ, .up, .down, .up),               // ↑↓↑
         VowelPattern(.ㅛ, .up, .downRight, .up),          // ↖↘↖ (정규화 후)
+        VowelPattern(.ㅛ, .up, .down, .upRight),          // ↑↓↗ (세 번째 획이 ↗로 빠질 때)
+        VowelPattern(.ㅛ, .up, .downRight, .upRight),     // ↑↘↗ (중간+세 번째 모두 오른쪽 대각선)
         VowelPattern(.ㅠ, .down, .up, .down),             // ↓↑↓
         VowelPattern(.ㅠ, .down, .upRight, .down),        // ↙↗↙ (정규화 후)
+        VowelPattern(.ㅠ, .down, .up, .downRight),        // ↓↑↘ (세 번째 획이 ↘로 빠질 때)
+        VowelPattern(.ㅠ, .down, .upRight, .downRight),   // ↓↗↘ (중간+세 번째 모두 오른쪽 대각선)
         VowelPattern(.ㅑ, .right, .left, .right),         // →←→
         VowelPattern(.ㅕ, .left, .right, .left),          // ←→←
 

--- a/MoakiKeyboard/Utilities/KeyboardMetrics.swift
+++ b/MoakiKeyboard/Utilities/KeyboardMetrics.swift
@@ -28,6 +28,7 @@ enum KeyboardMetrics {
 
     // Gesture thresholds
     static let gestureThreshold: CGFloat = 20        // Minimum distance to register direction
+    static let reversalThreshold: CGFloat = 10       // Lower threshold for opposite direction reversals
     static let directionChangeThreshold: CGFloat = 15 // Distance before direction can change
     static let gestureTimeout: TimeInterval = 0.5    // Max time between direction changes
 

--- a/MoakiKeyboardTests/GestureAnalyzerTests.swift
+++ b/MoakiKeyboardTests/GestureAnalyzerTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import MoakiKeyboard
+
+final class GestureAnalyzerTests: XCTestCase {
+
+    // MARK: - Reversal Threshold Tests
+
+    func testReversalDetectedAtLowerThreshold() {
+        // With reversalThreshold=10, opposite direction change should be detected at 10px
+        let analyzer = GestureAnalyzer(threshold: 20, reversalThreshold: 10, directionChangeThreshold: 15)
+
+        // Start at origin, move up 25px (above threshold=20)
+        analyzer.addPoint(CGPoint(x: 100, y: 100))
+        analyzer.addPoint(CGPoint(x: 100, y: 75))  // 25px up (iOS y-axis: lower y = up)
+
+        XCTAssertEqual(analyzer.getDirections(), [.up])
+
+        // Now reverse down by only 12px from direction change point (above reversal=10, below threshold=20)
+        analyzer.addPoint(CGPoint(x: 100, y: 87))  // 12px down from y=75
+
+        XCTAssertEqual(analyzer.getDirections(), [.up, .down], "Opposite reversal should be detected at reversal threshold (10px)")
+    }
+
+    func testNonReversalRequiresFullThreshold() {
+        // Non-opposite direction changes should still require the full threshold
+        let analyzer = GestureAnalyzer(threshold: 20, reversalThreshold: 10, directionChangeThreshold: 15)
+
+        // Start at origin, move up 25px
+        analyzer.addPoint(CGPoint(x: 100, y: 100))
+        analyzer.addPoint(CGPoint(x: 100, y: 75))  // 25px up
+
+        XCTAssertEqual(analyzer.getDirections(), [.up])
+
+        // Try to move right by only 12px (non-opposite direction, below threshold=20)
+        analyzer.addPoint(CGPoint(x: 112, y: 75))  // 12px right from direction change point
+
+        XCTAssertEqual(analyzer.getDirections(), [.up], "Non-opposite direction change should require full threshold")
+    }
+
+    func testTripleReversalForYoVowel() {
+        // Simulate ㅛ gesture: up → down → up with small amplitude
+        let analyzer = GestureAnalyzer(threshold: 20, reversalThreshold: 10, directionChangeThreshold: 15)
+
+        // First direction: up 25px
+        analyzer.addPoint(CGPoint(x: 100, y: 100))
+        analyzer.addPoint(CGPoint(x: 100, y: 75))  // 25px up
+
+        XCTAssertEqual(analyzer.getDirections(), [.up])
+
+        // Second direction (reversal): down 12px
+        analyzer.addPoint(CGPoint(x: 100, y: 87))  // 12px down from y=75
+
+        XCTAssertEqual(analyzer.getDirections(), [.up, .down])
+
+        // Third direction (reversal): up 12px
+        analyzer.addPoint(CGPoint(x: 100, y: 75))  // 12px up from y=87
+
+        let finalDirs = analyzer.finalizeGesture()
+        XCTAssertEqual(finalDirs, [.up, .down, .up], "Triple reversal should produce ㅛ pattern (↑↓↑)")
+    }
+
+    func testTripleReversalForYuVowel() {
+        // Simulate ㅠ gesture: down → up → down with small amplitude
+        let analyzer = GestureAnalyzer(threshold: 20, reversalThreshold: 10, directionChangeThreshold: 15)
+
+        // First direction: down 25px
+        analyzer.addPoint(CGPoint(x: 100, y: 100))
+        analyzer.addPoint(CGPoint(x: 100, y: 125))  // 25px down
+
+        XCTAssertEqual(analyzer.getDirections(), [.down])
+
+        // Second direction (reversal): up 12px
+        analyzer.addPoint(CGPoint(x: 100, y: 113))  // 12px up from y=125
+
+        XCTAssertEqual(analyzer.getDirections(), [.down, .up])
+
+        // Third direction (reversal): down 12px
+        analyzer.addPoint(CGPoint(x: 100, y: 125))  // 12px down from y=113
+
+        let finalDirs = analyzer.finalizeGesture()
+        XCTAssertEqual(finalDirs, [.down, .up, .down], "Triple reversal should produce ㅠ pattern (↓↑↓)")
+    }
+
+    func testFirstDirectionAlwaysRequiresFullThreshold() {
+        // First direction should always need the full threshold, never reversal threshold
+        let analyzer = GestureAnalyzer(threshold: 20, reversalThreshold: 10, directionChangeThreshold: 15)
+
+        // Move only 12px (above reversal=10 but below threshold=20)
+        analyzer.addPoint(CGPoint(x: 100, y: 100))
+        analyzer.addPoint(CGPoint(x: 100, y: 88))  // 12px up
+
+        XCTAssertEqual(analyzer.getDirections(), [], "First direction should require full threshold")
+    }
+
+    // MARK: - isOpposite Tests
+
+    func testIsOpposite() {
+        XCTAssertTrue(GestureDirection.up.isOpposite(to: .down))
+        XCTAssertTrue(GestureDirection.down.isOpposite(to: .up))
+        XCTAssertTrue(GestureDirection.left.isOpposite(to: .right))
+        XCTAssertTrue(GestureDirection.right.isOpposite(to: .left))
+        XCTAssertTrue(GestureDirection.upLeft.isOpposite(to: .downRight))
+        XCTAssertTrue(GestureDirection.downRight.isOpposite(to: .upLeft))
+        XCTAssertTrue(GestureDirection.upRight.isOpposite(to: .downLeft))
+        XCTAssertTrue(GestureDirection.downLeft.isOpposite(to: .upRight))
+    }
+
+    func testIsNotOpposite() {
+        XCTAssertFalse(GestureDirection.up.isOpposite(to: .right))
+        XCTAssertFalse(GestureDirection.up.isOpposite(to: .upRight))
+        XCTAssertFalse(GestureDirection.downRight.isOpposite(to: .upRight))
+        XCTAssertFalse(GestureDirection.left.isOpposite(to: .downLeft))
+    }
+}

--- a/MoakiKeyboardTests/VowelResolverTests.swift
+++ b/MoakiKeyboardTests/VowelResolverTests.swift
@@ -53,6 +53,22 @@ final class VowelResolverTests: XCTestCase {
         XCTAssertEqual(resolver.resolve(directions: [.left, .right, .left]).vowel, .ㅕ)
     }
 
+    // MARK: - Y-Vowel Diagonal Drift Tests
+
+    func testYVowelDiagonalDrift() {
+        // ㅛ = ↑↓↗ (세 번째 획이 ↗로 빠질 때)
+        XCTAssertEqual(resolver.resolve(directions: [.up, .down, .upRight]).vowel, .ㅛ)
+
+        // ㅛ = ↑↘↗ (중간+세 번째 모두 오른쪽 대각선)
+        XCTAssertEqual(resolver.resolve(directions: [.up, .downRight, .upRight]).vowel, .ㅛ)
+
+        // ㅠ = ↓↑↘ (세 번째 획이 ↘로 빠질 때)
+        XCTAssertEqual(resolver.resolve(directions: [.down, .up, .downRight]).vowel, .ㅠ)
+
+        // ㅠ = ↓↗↘ (중간+세 번째 모두 오른쪽 대각선)
+        XCTAssertEqual(resolver.resolve(directions: [.down, .upRight, .downRight]).vowel, .ㅠ)
+    }
+
     // MARK: - Complex Vowel Tests (Diphthongs)
 
     func testDiphthongs() {


### PR DESCRIPTION
## Summary
- GestureAnalyzer에서 방향 반전(↑↔↓, ←↔→ 등) 감지 시 임계값을 20px → 10px로 낮춰 ㅛ/ㅠ 왕복 제스처 인식률 개선
- 대각선 드리프트 대응을 위한 4개의 추가 모음 패턴 (↑↓↗, ↑↘↗, ↓↑↘, ↓↗↘)
- 기존 모음(ㅘ, ㅝ, ㅚ, ㅟ 등)은 비반전 전환이므로 영향 없음

## Changes
- `GestureDirection.swift`: `isOpposite(to:)` 메서드 추가
- `KeyboardMetrics.swift`: `reversalThreshold = 10` 상수 추가
- `GestureAnalyzer.swift`: 반전 방향에 대해 낮은 임계값 적용
- `VowelPattern.swift`: ㅛ/ㅠ 대각선 드리프트 패턴 4개 추가
- `GestureAnalyzerTests.swift`: 반전 임계값 테스트 (신규)
- `VowelResolverTests.swift`: 대각선 드리프트 패턴 테스트 추가

## Test plan
- [ ] 시뮬레이터/실기기에서 ㅛ, ㅠ 제스처 인식 확인
- [x] 기존 모음(ㅗ, ㅜ, ㅚ, ㅟ, ㅘ, ㅝ, ㅢ) 정상 동작 확인
- [x] ㅑ, ㅕ, ㅐ, ㅔ 왕복 제스처 정상 동작 확인

close #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)