### PR TITLE
Keyboard got super large after switching app to background and revisit to foreground

### DIFF
--- a/MoakiKeyboard/KeyboardViewController.swift
+++ b/MoakiKeyboard/KeyboardViewController.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 class KeyboardViewController: UIInputViewController {
 
-    private var keyboardView: UIHostingController<KeyboardView>?
+    private var keyboardView: UIViewController?
     private let viewModel = KeyboardViewModel()
     private var feedbackGenerator: UIImpactFeedbackGenerator?
+    private var heightConstraint: NSLayoutConstraint?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,19 +23,24 @@ class KeyboardViewController: UIInputViewController {
         )
         heightConstraint.priority = .required
         view.addConstraint(heightConstraint)
+        self.heightConstraint = heightConstraint
 
         viewModel.delegate = self
         setupKeyboardView()
         setupHapticFeedback()
     }
 
-    override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
-        keyboardView?.view.frame = view.bounds
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        heightConstraint?.constant = 260
+        heightConstraint?.isActive = true
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
     }
 
     private func setupKeyboardView() {
-        let hostingController = UIHostingController(rootView: KeyboardView(viewModel: viewModel))
+        let rootView = KeyboardView(viewModel: viewModel).ignoresSafeArea(.all)
+        let hostingController = UIHostingController(rootView: rootView)
         hostingController.view.backgroundColor = .clear
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios-moaki.xcodeproj/xcuserdata/jeffrey.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios-moaki.xcodeproj/xcuserdata/jeffrey.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>MoakiKeyboard.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>ios-moaki.xcscheme_^#shared#^_</key>
 		<dict>


### PR DESCRIPTION
## Summary

- Store the 260pt height constraint as a property so it can be re-validated after lifecycle transitions
- Add `viewWillAppear` override to force correct keyboard height every time the keyboard appears (including after background→foreground)
- Add `.ignoresSafeArea(.all)` to the SwiftUI root view to prevent `UIHostingController` from injecting safe area insets that cause sizing conflicts
- Remove redundant frame-setting in `viewWillLayoutSubviews` that conflicted with Auto Layout constraints

## Original Issue

**키보드가 열린 채로 홈화면으로 나가 앱이 백그라운드에 저장되었다가, 다시 앱을 키면 (포그라운드로 전환) 키보드가 굉장히 커짐 (화면을 다 덮어버림)**

## Test plan

- [ ] Open a text field and activate the Moaki keyboard
- [ ] Press Home to background the app
- [ ] Return to the app — keyboard should remain at normal size (260pt)
- [ ] Repeat several times to confirm stability
- [ ] Verify normal keyboard functionality (typing, gestures) still works

close #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)