### PR TITLE
Refactor the number pad

### DIFF
--- a/MoakiKeyboard/Utilities/KeyboardMetrics.swift
+++ b/MoakiKeyboard/Utilities/KeyboardMetrics.swift
@@ -32,6 +32,9 @@ enum KeyboardMetrics {
     static let directionChangeThreshold: CGFloat = 15 // Distance before direction can change
     static let gestureTimeout: TimeInterval = 0.5    // Max time between direction changes
 
+    // Symbol keypad uses a simple 3-column layout.
+    static let symbolColumns = 3
+
     // Calculate action key width (backspace/return) based on total width
     static func actionKeyWidth(for totalWidth: CGFloat) -> CGFloat {
         return totalWidth * actionKeyWidthRatio
@@ -45,6 +48,13 @@ enum KeyboardMetrics {
         return availableWidth / (symbolWidthRatio * 2 + 5)
     }
 
+    // Calculate symbol keypad key width for 3 columns.
+    static func symbolKeyWidth(for totalWidth: CGFloat) -> CGFloat {
+        let spacing = keySpacing * CGFloat(symbolColumns + 1)  // gaps + edges
+        let availableWidth = totalWidth - spacing
+        return availableWidth / CGFloat(symbolColumns)
+    }
+
     // Calculate key height based on available space
     static func keyHeight(for totalHeight: CGFloat) -> CGFloat {
         let availableHeight = totalHeight - functionRowHeight - keySpacing * CGFloat(gridRows + 2)
@@ -52,7 +62,11 @@ enum KeyboardMetrics {
     }
 
     // Get key width for specific column and row
-    static func keyWidth(for column: Int, row: Int, centerKeyWidth: CGFloat, totalWidth: CGFloat) -> CGFloat {
+    static func keyWidth(for column: Int, row: Int, centerKeyWidth: CGFloat, totalWidth: CGFloat, isSymbolMode: Bool) -> CGFloat {
+        if isSymbolMode {
+            return symbolKeyWidth(for: totalWidth)
+        }
+
         let sideWidth = centerKeyWidth * symbolWidthRatio
 
         // Row 3: backspace (col 5) fills remaining space to match row 0-2 width
@@ -71,9 +85,11 @@ enum KeyboardMetrics {
         return centerKeyWidth
     }
 
-    // Get number of columns for a row (row 3 has 6 columns, others have 7)
-    static func columnCount(for row: Int) -> Int {
-        return row == 3 ? 6 : 7
+    // Get number of columns for a row in the active layout.
+    static func columnCount(for row: Int, isSymbolMode: Bool) -> Int {
+        let layout = isSymbolMode ? symbolLayout : koreanLayout
+        guard row >= 0 && row < layout.count else { return 0 }
+        return layout[row].count
     }
 
     // Calculate key size based on available width (legacy method for compatibility)
@@ -93,13 +109,16 @@ enum KeyboardMetrics {
         [.symbol("*"), .consonant(.ㅋ), .consonant(.ㅌ), .consonant(.ㅊ), .consonant(.ㅍ), .backspace],  // 6 columns
     ]
 
-    // Symbol/number mode layout (7 columns for rows 0-2, 6 columns for row 3)
-    // Numbers in center columns, extra symbols on sides
+    // Symbol/number mode keypad layout.
+    // 1 2 3
+    // 4 5 6
+    // 7 8 9
+    // # 0 *
     static let symbolLayout: [[KeyContent]] = [
-        [.symbol("`"), .symbol("1"), .symbol("2"), .symbol("3"), .symbol("4"), .symbol("5"), .symbol("/")],
-        [.symbol("\\"), .symbol("6"), .symbol("7"), .symbol("8"), .symbol("9"), .symbol("0"), .symbol("=")],
-        [.symbol("|"), .symbol("-"), .symbol("+"), .symbol("@"), .symbol("#"), .symbol("$"), .symbol("%")],
-        [.symbol("&"), .symbol("("), .symbol(")"), .symbol("'"), .symbol("\""), .backspace],  // 6 columns
+        [.symbol("1"), .symbol("2"), .symbol("3")],
+        [.symbol("4"), .symbol("5"), .symbol("6")],
+        [.symbol("7"), .symbol("8"), .symbol("9")],
+        [.symbol("#"), .symbol("0"), .symbol("*")],
     ]
 
     // Long press number mapping for Korean mode

--- a/MoakiKeyboard/Views/ConsonantGridView.swift
+++ b/MoakiKeyboard/Views/ConsonantGridView.swift
@@ -19,13 +19,19 @@ struct KeyGridView: View {
         VStack(spacing: KeyboardMetrics.keySpacing) {
             ForEach(0..<KeyboardMetrics.gridRows, id: \.self) { row in
                 HStack(spacing: KeyboardMetrics.keySpacing) {
-                    let columnCount = KeyboardMetrics.columnCount(for: row)
+                    let columnCount = KeyboardMetrics.columnCount(for: row, isSymbolMode: isSymbolMode)
 
                     ForEach(0..<columnCount, id: \.self) { column in
                         let content = KeyboardMetrics.keyContent(at: row, column: column, isSymbolMode: isSymbolMode)
                         let isActive = activeKey?.row == row && activeKey?.column == column
                         let longPressNumber = isSymbolMode ? nil : KeyboardMetrics.longPressNumber(at: row, column: column)
-                        let width = KeyboardMetrics.keyWidth(for: column, row: row, centerKeyWidth: centerKeyWidth, totalWidth: totalWidth)
+                        let width = KeyboardMetrics.keyWidth(
+                            for: column,
+                            row: row,
+                            centerKeyWidth: centerKeyWidth,
+                            totalWidth: totalWidth,
+                            isSymbolMode: isSymbolMode
+                        )
 
                         KeyView(
                             content: content ?? .symbol(""),

--- a/MoakiKeyboard/Views/FunctionRowView.swift
+++ b/MoakiKeyboard/Views/FunctionRowView.swift
@@ -5,6 +5,7 @@ struct FunctionRowView: View {
     let isSymbolMode: Bool
     let onToggleModePressed: () -> Void
     let onCommaPressed: () -> Void
+    let onBackspacePressed: () -> Void
     let onSpacePressed: () -> Void
     let onReturnPressed: () -> Void
 
@@ -27,12 +28,19 @@ struct FunctionRowView: View {
             // Comma key (left of space)
             FunctionKeyView(
                 content: AnyView(
-                    Text(",")
-                        .font(.system(size: 20))
+                    Group {
+                        if isSymbolMode {
+                            Image(systemName: "delete.left")
+                                .font(.system(size: 18))
+                        } else {
+                            Text(",")
+                                .font(.system(size: 20))
+                        }
+                    }
                 ),
                 width: commaWidth,
                 height: height,
-                action: onCommaPressed
+                action: isSymbolMode ? onBackspacePressed : onCommaPressed
             )
 
             // Space bar
@@ -123,6 +131,7 @@ struct FunctionKeyView: View {
             isSymbolMode: false,
             onToggleModePressed: { print("Toggle") },
             onCommaPressed: { print("Comma") },
+            onBackspacePressed: { print("Backspace") },
             onSpacePressed: { print("Space") },
             onReturnPressed: { print("Return") }
         )
@@ -134,6 +143,7 @@ struct FunctionKeyView: View {
             isSymbolMode: true,
             onToggleModePressed: { print("Toggle") },
             onCommaPressed: { print("Comma") },
+            onBackspacePressed: { print("Backspace") },
             onSpacePressed: { print("Space") },
             onReturnPressed: { print("Return") }
         )

--- a/MoakiKeyboard/Views/KeyboardView.swift
+++ b/MoakiKeyboard/Views/KeyboardView.swift
@@ -53,6 +53,9 @@ struct KeyboardView: View {
                         onCommaPressed: {
                             viewModel.inputSymbol(",")
                         },
+                        onBackspacePressed: {
+                            viewModel.deleteBackward()
+                        },
                         onSpacePressed: {
                             viewModel.inputSpace()
                         },


### PR DESCRIPTION
## Summary
- Refactored symbol mode into a number pad layout using a 3x3 grid plus bottom row `# 0 *`.
- Updated grid metrics so symbol mode uses uniform 3-column key widths while Korean mode keeps its existing layout.
- Kept delete functionality in symbol mode by showing backspace on the function row.

## Original Issue
The number pad should be like the number pad location
3*3 and 0 at down there
123
456
789
#0*

close #8
