### PR TITLE
Number keypad long press display bug

### DIFF
--- a/MoakiKeyboard/Views/KeyboardView.swift
+++ b/MoakiKeyboard/Views/KeyboardView.swift
@@ -33,7 +33,7 @@ struct KeyboardView: View {
                             viewModel.endBackspacePress()
                         },
                         onLongPressNumber: { number in
-                            viewModel.inputNumber(number)
+                            viewModel.inputLongPressNumber(number)
                         },
                         onGestureStart: { row, column, point in
                             viewModel.gestureStarted(row: row, column: column, at: point)
@@ -100,6 +100,7 @@ class KeyboardViewModel: ObservableObject {
     private var isBackspacePressing = false
     private var backspaceInitialDelayTimer: Timer?
     private var backspaceRepeatTimer: Timer?
+    private var didHandleLongPressNumberInCurrentGesture = false
 
     weak var delegate: KeyboardViewModelDelegate?
 
@@ -151,6 +152,11 @@ class KeyboardViewModel: ObservableObject {
         triggerHapticFeedback()
     }
 
+    func inputLongPressNumber(_ number: String) {
+        didHandleLongPressNumberInCurrentGesture = true
+        inputNumber(number)
+    }
+
     func deleteBackward() {
         let action = composer.deleteBackward()
         if action == .none {
@@ -192,6 +198,7 @@ class KeyboardViewModel: ObservableObject {
     // MARK: - Gesture Handling
 
     func gestureStarted(row: Int, column: Int, at point: CGPoint) {
+        didHandleLongPressNumberInCurrentGesture = false
         activeKey = (row, column)
         gestureStartPoint = point
         gestureAnalyzer.reset()
@@ -210,6 +217,12 @@ class KeyboardViewModel: ObservableObject {
     }
 
     func gestureEnded(row: Int, column: Int) {
+        if didHandleLongPressNumberInCurrentGesture {
+            didHandleLongPressNumberInCurrentGesture = false
+            resetGestureState()
+            return
+        }
+
         // In symbol mode, gesture handling is simpler - just tap
         if isSymbolMode {
             handleSymbolModeTap(row: row, column: column)
@@ -275,6 +288,7 @@ class KeyboardViewModel: ObservableObject {
     /// or lastComposingText to preserve in-progress Hangul composition.
     func resetGestureState() {
         stopBackspaceRepeat()
+        didHandleLongPressNumberInCurrentGesture = false
         activeKey = nil
         gestureStartPoint = nil
         gestureDirections = []

--- a/MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift
+++ b/MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import MoakiKeyboard
+
+final class KeyboardViewModelLongPressTests: XCTestCase {
+    private var viewModel: KeyboardViewModel!
+    private var delegate: SpyKeyboardDelegate!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = KeyboardViewModel()
+        delegate = SpyKeyboardDelegate()
+        viewModel.delegate = delegate
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        delegate = nil
+        super.tearDown()
+    }
+
+    func testLongPressNumberThenGestureEnd_insertsOnlyNumber() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero) // ㅂ key
+        viewModel.inputLongPressNumber("1")
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        XCTAssertEqual(delegate.insertedTexts, ["1"])
+        XCTAssertTrue(delegate.composingUpdates.isEmpty)
+    }
+
+    func testNormalTapStillInputsConsonant() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero) // ㅂ key
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        XCTAssertEqual(delegate.insertedTexts, [])
+        XCTAssertEqual(delegate.composingUpdates.last?.current, "ㅂ")
+    }
+
+    func testLongPressSuppressionResetsForNextGesture() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero)
+        viewModel.inputLongPressNumber("1")
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        viewModel.gestureStarted(row: 1, column: 2, at: .zero) // ㅈ key
+        viewModel.gestureEnded(row: 1, column: 2)
+
+        XCTAssertEqual(delegate.insertedTexts, ["1"])
+        XCTAssertEqual(delegate.composingUpdates.last?.current, "ㅈ")
+    }
+}
+
+private final class SpyKeyboardDelegate: KeyboardViewModelDelegate {
+    struct ComposingUpdate: Equatable {
+        let previous: String
+        let current: String
+    }
+
+    var insertedTexts: [String] = []
+    var deleteCount = 0
+    var composingUpdates: [ComposingUpdate] = []
+    var switchKeyboardCount = 0
+    var hapticCount = 0
+
+    func insertText(_ text: String) {
+        insertedTexts.append(text)
+    }
+
+    func deleteBackward() {
+        deleteCount += 1
+    }
+
+    func updateComposingText(from previous: String, to current: String) {
+        composingUpdates.append(.init(previous: previous, current: current))
+    }
+
+    func switchToNextKeyboard() {
+        switchKeyboardCount += 1
+    }
+
+    func triggerHapticFeedback() {
+        hapticCount += 1
+    }
+}

--- a/docs/plans/2026-02-24-hotfix-15-number-keypad-long-press-design.md
+++ b/docs/plans/2026-02-24-hotfix-15-number-keypad-long-press-design.md
@@ -1,0 +1,77 @@
+# HotFix #15 Number Keypad Long-Press Design
+
+**Date:** 2026-02-24  
+**Issue:** `#15` Number keypad long press display bug  
+**Reported behavior:** Long-pressing `ㅂ` inserts `1` and then also inserts `ㅂ` (`1ㅂ`).
+
+## Problem Statement
+
+Long press on mapped Korean consonant keys should produce only the mapped number.  
+Current behavior inserts the number on long press and then inserts the consonant on touch end.
+
+## Root Cause Summary
+
+Current event flow:
+
+1. `KeyView.startLongPressTimer()` fires and calls `onLongPress?(number)` after 0.5s.
+2. `KeyboardView` handles that callback by calling `viewModel.inputNumber(number)`.
+3. On finger release, `KeyView` always calls `onGestureEnd()`.
+4. `KeyboardViewModel.gestureEnded(...)` treats the same interaction as a normal Korean key gesture and inputs consonant `ㅂ` when directions are empty.
+
+Result: number + consonant for one long-press gesture.
+
+## Assumptions For This Hotfix
+
+- Long press on mapped Korean keys inserts number only.
+- The follow-up touch-end event for that same gesture must not insert consonant.
+- Normal tap and drag-to-vowel behavior remains unchanged.
+
+## Approaches
+
+### 1) Consume touch-end in `KeyView`
+
+- Add local state in `KeyView` to skip `onGestureEnd()` after long press.
+- Pros: Fix is close to gesture source.
+- Cons: Harder to unit test in current XCTest setup (SwiftUI gesture/timer behavior).
+
+### 2) Suppress next `gestureEnded` in `KeyboardViewModel` (Recommended)
+
+- Add a view-model flag for "long press number already handled for active gesture".
+- Route long-press callback through a dedicated view-model API that sets the flag.
+- `gestureEnded` early-returns when flag is set.
+- Pros: Minimal surface change, testable via unit tests without UI harness.
+- Cons: Requires small state coordination in view model.
+
+### 3) Refactor key interaction into explicit event enum
+
+- Replace multiple callbacks with single `KeyInteractionResult` (`tap`, `gesture`, `longPressNumber`, `backspacePress`).
+- Pros: Best long-term clarity.
+- Cons: Too large for hotfix scope, higher regression risk.
+
+## Recommended Design
+
+Use approach 2.
+
+- Add `didHandleLongPressNumber` state in `KeyboardViewModel`.
+- Add `inputLongPressNumber(_:)` in `KeyboardViewModel`:
+  - Set `didHandleLongPressNumber = true`
+  - Reuse existing `inputNumber(_:)`
+- In `gestureStarted(...)`, reset the flag to `false`.
+- In `gestureEnded(...)`, if flag is true:
+  - Reset flag
+  - Call `resetGestureState()`
+  - Return without consonant/symbol processing.
+- In `KeyboardView`, route `onLongPressNumber` to `viewModel.inputLongPressNumber(...)` instead of `inputNumber(...)`.
+
+## Test Strategy
+
+- Add dedicated unit tests for `KeyboardViewModel` long-press behavior:
+  - Long press number + gesture end inserts only number.
+  - Normal tap still inserts consonant.
+  - Suppression applies only to the long-press gesture and clears for the next gesture.
+
+## Acceptance Criteria
+
+- Repro case: long press `ㅂ` inserts `1` only (no trailing `ㅂ`).
+- No regressions in normal consonant tap or vowel gesture behavior.
+- Unit tests covering the above behavior pass in `MoakiKeyboardTests`.

--- a/docs/plans/2026-02-24-hotfix-15-number-keypad-long-press.md
+++ b/docs/plans/2026-02-24-hotfix-15-number-keypad-long-press.md
@@ -1,0 +1,215 @@
+# HotFix #15 Number Keypad Long-Press Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent duplicate consonant insertion after long-press number input on Korean consonant keys.
+
+**Architecture:** Keep gesture ownership in `KeyView`, but make long-press consumption explicit in `KeyboardViewModel`. A dedicated long-press entrypoint marks the current gesture as handled and `gestureEnded` skips normal consonant resolution for that one interaction.
+
+**Tech Stack:** Swift, SwiftUI, XCTest, `xcodebuild`
+
+---
+
+### Task 1: Add Failing Regression Tests For Long-Press Number Flow
+
+**Files:**
+- Create: `MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift`
+- Test: `MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+import XCTest
+@testable import MoakiKeyboard
+
+final class KeyboardViewModelLongPressTests: XCTestCase {
+    private var viewModel: KeyboardViewModel!
+    private var delegate: SpyKeyboardDelegate!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = KeyboardViewModel()
+        delegate = SpyKeyboardDelegate()
+        viewModel.delegate = delegate
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        delegate = nil
+        super.tearDown()
+    }
+
+    func testLongPressNumberThenGestureEnd_insertsOnlyNumber() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero) // ㅂ key
+        viewModel.inputLongPressNumber("1")
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        XCTAssertEqual(delegate.insertedTexts, ["1"])
+        XCTAssertEqual(delegate.composingUpdates.count, 0)
+    }
+
+    func testNormalTapStillInputsConsonant() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero) // ㅂ key
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        XCTAssertEqual(delegate.insertedTexts, [])
+        XCTAssertEqual(delegate.composingUpdates.last?.current, "ㅂ")
+    }
+
+    func testLongPressSuppressionResetsForNextGesture() {
+        viewModel.gestureStarted(row: 1, column: 1, at: .zero)
+        viewModel.inputLongPressNumber("1")
+        viewModel.gestureEnded(row: 1, column: 1)
+
+        viewModel.gestureStarted(row: 1, column: 2, at: .zero) // ㅈ key
+        viewModel.gestureEnded(row: 1, column: 2)
+
+        XCTAssertEqual(delegate.insertedTexts, ["1"])
+        XCTAssertEqual(delegate.composingUpdates.last?.current, "ㅈ")
+    }
+}
+
+private final class SpyKeyboardDelegate: KeyboardViewModelDelegate {
+    struct ComposingUpdate: Equatable {
+        let previous: String
+        let current: String
+    }
+
+    var insertedTexts: [String] = []
+    var deleteCount = 0
+    var composingUpdates: [ComposingUpdate] = []
+    var switchKeyboardCount = 0
+    var hapticCount = 0
+
+    func insertText(_ text: String) { insertedTexts.append(text) }
+    func deleteBackward() { deleteCount += 1 }
+    func updateComposingText(from previous: String, to current: String) {
+        composingUpdates.append(.init(previous: previous, current: current))
+    }
+    func switchToNextKeyboard() { switchKeyboardCount += 1 }
+    func triggerHapticFeedback() { hapticCount += 1 }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -scheme MoakiKeyboardTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MoakiKeyboardTests/KeyboardViewModelLongPressTests`  
+Expected: FAIL (missing `inputLongPressNumber(_:)` and/or duplicate consonant behavior).
+
+**Step 3: Commit**
+
+```bash
+git add MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift
+git commit -m "test: add long-press number regression coverage"
+```
+
+### Task 2: Implement Long-Press Consumption In KeyboardViewModel
+
+**Files:**
+- Modify: `MoakiKeyboard/Views/KeyboardView.swift`
+- Test: `MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift`
+
+**Step 1: Write minimal implementation**
+
+```swift
+final class KeyboardViewModel: ObservableObject {
+    // ...
+    private var didHandleLongPressNumber = false
+
+    func inputLongPressNumber(_ number: String) {
+        didHandleLongPressNumber = true
+        inputNumber(number)
+    }
+
+    func gestureStarted(row: Int, column: Int, at point: CGPoint) {
+        didHandleLongPressNumber = false
+        activeKey = (row, column)
+        gestureStartPoint = point
+        gestureAnalyzer.reset()
+        gestureAnalyzer.addPoint(point)
+        gestureDirections = []
+        previewVowel = nil
+    }
+
+    func gestureEnded(row: Int, column: Int) {
+        if didHandleLongPressNumber {
+            didHandleLongPressNumber = false
+            resetGestureState()
+            return
+        }
+
+        if isSymbolMode {
+            handleSymbolModeTap(row: row, column: column)
+        } else {
+            handleKoreanModeGesture(row: row, column: column)
+        }
+        resetGestureState()
+    }
+}
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `xcodebuild test -scheme MoakiKeyboardTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MoakiKeyboardTests/KeyboardViewModelLongPressTests`  
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add MoakiKeyboard/Views/KeyboardView.swift
+git commit -m "fix: suppress gesture-end consonant after long-press number"
+```
+
+### Task 3: Route Long-Press Callback Through Dedicated ViewModel API
+
+**Files:**
+- Modify: `MoakiKeyboard/Views/KeyboardView.swift`
+
+**Step 1: Wire callback**
+
+```swift
+onLongPressNumber: { number in
+    viewModel.inputLongPressNumber(number)
+},
+```
+
+**Step 2: Run focused tests**
+
+Run: `xcodebuild test -scheme MoakiKeyboardTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MoakiKeyboardTests/KeyboardViewModelLongPressTests`  
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add MoakiKeyboard/Views/KeyboardView.swift
+git commit -m "refactor: route long-press number via dedicated viewmodel entrypoint"
+```
+
+### Task 4: Full Verification And Hotfix Exit Criteria
+
+**Files:**
+- Verify only (no file changes expected)
+
+**Step 1: Run project test suite**
+
+Run: `xcodebuild test -scheme MoakiKeyboardTests -destination 'platform=iOS Simulator,name=iPhone 17'`  
+Expected: PASS.
+
+**Step 2: Run extension build smoke test**
+
+Run: `xcodebuild -quiet build -scheme MoakiKeyboard -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -derivedDataPath /tmp/ios-moaki-derived`  
+Expected: BUILD SUCCEEDED.
+
+**Step 3: Manual validation on simulator**
+
+1. Switch to Korean mode.
+2. Long press `ㅂ` key.
+3. Confirm only `1` is inserted.
+4. Tap `ㅂ` normally afterward and confirm consonant input still works.
+
+**Step 4: Final commit**
+
+```bash
+git add MoakiKeyboard/Views/KeyboardView.swift MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift
+git commit -m "hotfix: prevent duplicate consonant after number-key long press (#15)"
+```


### PR DESCRIPTION
## Summary
- Prevent duplicate input on long-press number keys by consuming the gesture-end consonant path for that gesture.
- Route long-press callback through a dedicated `inputLongPressNumber` API in `KeyboardViewModel`.
- Add regression tests for long-press number handling in `MoakiKeyboardTests/KeyboardViewModelLongPressTests.swift`.
- Add hotfix design and implementation plan docs under `docs/plans/`.

## Original Issue
Long press number keypad does not working properly. When press long ㅂ, the actual word will be 1ㅂ

close #15
